### PR TITLE
Send webhook for activity on a pull request branch

### DIFF
--- a/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
+++ b/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
@@ -4,6 +4,7 @@ import com.atlassian.bitbucket.event.pull.PullRequestEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestMergedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestOpenedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestReopenedEvent;
+import com.atlassian.bitbucket.event.pull.PullRequestRescopedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestUpdatedEvent;
 import com.atlassian.bitbucket.event.repository.AbstractRepositoryRefsChangedEvent;
 import com.atlassian.bitbucket.nav.NavBuilder;
@@ -67,6 +68,12 @@ public class PullRequestListener implements DisposableBean
 
 	@EventListener
 	public void reopenedEvent(PullRequestReopenedEvent event) throws IOException
+	{
+		sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
+	}
+
+	@EventListener
+	public void rescopedEvent(PullRequestRescopedEvent event) throws IOException
 	{
 		sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
 	}

--- a/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
+++ b/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
@@ -8,6 +8,8 @@ import com.atlassian.bitbucket.event.pull.PullRequestRescopedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestUpdatedEvent;
 import com.atlassian.bitbucket.event.repository.AbstractRepositoryRefsChangedEvent;
 import com.atlassian.bitbucket.nav.NavBuilder;
+import com.atlassian.bitbucket.pull.PullRequest;
+import com.atlassian.bitbucket.pull.PullRequestService;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.event.api.EventListener;
 import com.atlassian.event.api.EventPublisher;
@@ -43,14 +45,16 @@ public class PullRequestListener implements DisposableBean
 	private HttpClient httpClient;
 	private NavBuilder navBuilder;
 	private WebHookConfigurationDao webHookConfigurationDao;
+	private PullRequestService pullRequestService;
 
 	@Autowired
-	public PullRequestListener(@ComponentImport EventPublisher eventPublisher, @ComponentImport HttpClient httpClient, @ComponentImport NavBuilder navBuilder, WebHookConfigurationDao webHookConfigurationDao)
+	public PullRequestListener(@ComponentImport EventPublisher eventPublisher, @ComponentImport PullRequestService pullRequestService, @ComponentImport HttpClient httpClient, @ComponentImport NavBuilder navBuilder, WebHookConfigurationDao webHookConfigurationDao)
 	{
 		this.eventPublisher = eventPublisher;
 		this.httpClient = httpClient;
 		this.navBuilder = navBuilder;
 		this.webHookConfigurationDao = webHookConfigurationDao;
+		this.pullRequestService = pullRequestService;
 		eventPublisher.register(this);
 	}
 
@@ -75,7 +79,17 @@ public class PullRequestListener implements DisposableBean
 	@EventListener
 	public void rescopedEvent(PullRequestRescopedEvent event) throws IOException
 	{
-		sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
+		final PullRequest pullRequest = event.getPullRequest();
+
+		// see this atlassian page for explanation of the logic in this handler:
+		// https://answers.atlassian.com/questions/239988
+
+		// only trigger when changes were pushed to the "from" side of the PR
+		if (! event.getPreviousFromHash().equals(pullRequest.getFromRef().getLatestCommit())) {
+			// canMerge forces the update of refs in the destination repository
+			pullRequestService.canMerge(pullRequest.getToRef().getRepository().getId(), pullRequest.getId());
+			sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
+		}
 	}
 
 	@EventListener


### PR DESCRIPTION
This adds a Bitbucket event listener for the [PullRequestRescopedEvent](https://developer.atlassian.com/static/javadoc/bitbucket-server/latest/api/reference/com/atlassian/bitbucket/event/pull/PullRequestRescopedEvent.html) event.

This event is sent when commits are pushed to the branch a pull request is based on. The primary use case is pull requests based on a fork of the main repo. In this case the `repo:push` event is not sent, so builds are not triggered.

This *does* result in two different hooks being sent on push to a PR branch on the main repository (`repo:push` and `pullrequest:updated`). However I believe that is a reasonable and expected behavior - really these are separate events and webhook subscribers could have different behaviors. I did test with Jenkins Bitbucket Branch Source Plugin and found that though both hooks were received, only one build was started. 

Fixes #11.