### PR TITLE
Add atlassian repositories to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,38 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>atlassian-public</id>
+            <url>https://maven.atlassian.com/repository/public</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>warn</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>atlassian-public</id>
+            <url>https://maven.atlassian.com/repository/public</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+                <checksumPolicy>warn</checksumPolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
     <scm>
         <connection>scm:git:git@github.com:topicusfinan/bitbucket-webhooks-plugin.git</connection>
         <url>scm:git:git@github.com:topicusfinan/bitbucket-webhooks-plugin.git</url>


### PR DESCRIPTION
Some dependencies are not present in maven central. This change makes the project buildable by people who do not have the atlassian repositories configured in their settings.xml.