### PR TITLE
Listen for RepositoryRefsChangedEvent 

### DIFF
--- a/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
+++ b/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
@@ -7,7 +7,7 @@ import com.atlassian.bitbucket.event.pull.PullRequestOpenedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestReopenedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestRescopedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestUpdatedEvent;
-import com.atlassian.bitbucket.event.repository.AbstractRepositoryRefsChangedEvent;
+import com.atlassian.bitbucket.event.repository.RepositoryRefsChangedEvent;
 import com.atlassian.bitbucket.nav.NavBuilder;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
@@ -115,7 +115,7 @@ public class PullRequestListener implements DisposableBean
     }
 
     @EventListener
-    public void repoChangedEvent(AbstractRepositoryRefsChangedEvent event) throws IOException
+    public void repoChangedEvent(RepositoryRefsChangedEvent event) throws IOException
     {
         BitbucketPushEvent pushEvent = Events.createPushEvent(event, applicationPropertiesService);
         sendEvents(pushEvent, event.getRepository(), EventType.REPO_PUSH);

--- a/src/main/java/nl/topicus/bitbucket/events/Events.java
+++ b/src/main/java/nl/topicus/bitbucket/events/Events.java
@@ -1,7 +1,7 @@
 package nl.topicus.bitbucket.events;
 
 import com.atlassian.bitbucket.event.pull.PullRequestEvent;
-import com.atlassian.bitbucket.event.repository.AbstractRepositoryRefsChangedEvent;
+import com.atlassian.bitbucket.event.repository.RepositoryRefsChangedEvent;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.server.ApplicationPropertiesService;
 import nl.topicus.bitbucket.model.Models;
@@ -15,7 +15,7 @@ public final class Events
     {
     }
 
-    public static BitbucketPushEvent createPushEvent(AbstractRepositoryRefsChangedEvent event,
+    public static BitbucketPushEvent createPushEvent(RepositoryRefsChangedEvent event,
                                                      ApplicationPropertiesService appPropSvc)
     {
         BitbucketPushEvent pushEvent = new BitbucketPushEvent();


### PR DESCRIPTION
#31 
Use RepositoryRefsChangedEvent instead of AbstractRepositoryRefsChangedEvent to get all ref changes event.

