### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ before_install:
   - sudo apt-get install atlassian-plugin-sdk
 
 install:
-    - atlas-mvn -q org.apache.maven.plugins:maven-dependency-plugin:resolve-plugins
+    - atlas-mvn -q org.apache.maven.plugins:maven-dependency-plugin:resolve-plugins --batch-mode
 
 script:
   - atlas-clean
-  - atlas-mvn install -Dbitbucket.version=4.10.2
-  - atlas-mvn install -Dbitbucket.version=5.2.2
+  - atlas-mvn install --batch-mode -Dbitbucket.version=4.10.2
+  - atlas-mvn install --batch-mode -Dbitbucket.version=5.2.2
 
 cache:
 # Caching is not allowed for 'sudo: required' builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,27 @@ language: java
 
 jdk:
   - oraclejdk8
+  
+sudo: required
+
+before_install:
+  # Install Atlassian SDK
+  - sudo sh -c 'echo "deb https://sdkrepo.atlassian.com/debian/ stable contrib" >>/etc/apt/sources.list'
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B07804338C015B73
+  - sudo apt-get install apt-transport-https
+  - sudo apt-get update
+  - sudo apt-get install atlassian-plugin-sdk
+
+install:
+    - atlas-mvn -q org.apache.maven.plugins:maven-dependency-plugin:resolve-plugins
 
 script:
-  - mvn clean install -Dbitbucket.version=4.10.2
-  - mvn clean install -Dbitbucket.version=5.2.2
+  - atlas-clean
+  - atlas-mvn install -Dbitbucket.version=4.10.2
+  - atlas-mvn install -Dbitbucket.version=5.2.2
+
+cache:
+# Caching is not allowed for 'sudo: required' builds.
+# It is kept for future usage.
+  directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ install:
     - atlas-mvn -q org.apache.maven.plugins:maven-dependency-plugin:resolve-plugins --batch-mode
 
 script:
-  - atlas-clean
-  - atlas-mvn install --batch-mode -Dbitbucket.version=4.10.2
-  - atlas-clean
-  - atlas-mvn install --batch-mode -Dbitbucket.version=5.2.2
+  - atlas-mvn clean install --batch-mode -Dbitbucket.version=4.10.2
+  - atlas-mvn clean install --batch-mode -Dbitbucket.version=5.2.2
 
 cache:
 # Caching is not allowed for 'sudo: required' builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+script:
+  - mvn clean install -Dbitbucket.version=4.10.2
+  - mvn clean install -Dbitbucket.version=5.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 script:
   - atlas-clean
   - atlas-mvn install --batch-mode -Dbitbucket.version=4.10.2
+  - atlas-clean
   - atlas-mvn install --batch-mode -Dbitbucket.version=5.2.2
 
 cache:


### PR DESCRIPTION
Test different bitbucket version

Tested it on my fork, [First Build](https://travis-ci.org/casz/bitbucket-webhooks-plugin/builds/265385319)
is just the config file added on `testotravis` branch.
[Second build](https://travis-ci.org/casz/bitbucket-webhooks-plugin/builds/265386333) is PR #57 rebased onto `testotravis` branch.